### PR TITLE
pdksync - use Puppet 8 and Ruby 3.2 in CI pipelines

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        puppet_version: [7]
+        puppet_version: [8]
 
     name: Check / Puppet ${{ matrix.puppet_version }}
     runs-on: ubuntu-24.04
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['rocky8', 'ub2004', 'ub2204', 'ub2404', 'deb11', 'deb12']
-        puppet_version: [7]
+        puppet_version: [8]
 
     name: Acceptance / ${{ matrix.os }} / Puppet ${{ matrix.puppet_version }}
     runs-on: ubuntu-24.04
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.7"
+          ruby-version: "3.2"
           bundler-cache: true
 
       - name: Run Litmus

--- a/spec/classes/baculaweb_spec.rb
+++ b/spec/classes/baculaweb_spec.rb
@@ -16,7 +16,7 @@ describe 'baculaweb' do
         it {
           File.write(
             'catalog.json',
-            PSON.pretty_generate(catalogue),
+            JSON.pretty_generate(catalogue),
           )
           is_expected.to compile.with_all_deps
         }


### PR DESCRIPTION
use Puppet 8 and Ruby 3.2 in CI pipelines
pdk version: `3.4.0` 
